### PR TITLE
Replaced deprecated use of split with explode

### DIFF
--- a/diamond-bloglist.php
+++ b/diamond-bloglist.php
@@ -40,7 +40,7 @@ class DiamondBL {
 		
 		), $atts ) );
 
-		return $this->render_output(split(',',$exclude), $count, html_entity_decode($format), $avatar_size, $default_logo, $date_format, html_entity_decode($before_item), html_entity_decode($after_item), html_entity_decode($before_content), html_entity_decode($after_content), $more_text, $order_by, $order, split(',', $whitelist), $min_post_count, $comment_age);
+		return $this->render_output(explode(',',$exclude), $count, html_entity_decode($format), $avatar_size, $default_logo, $date_format, html_entity_decode($before_item), html_entity_decode($after_item), html_entity_decode($before_content), html_entity_decode($after_content), $more_text, $order_by, $order, explode(',', $whitelist), $min_post_count, $comment_age);
 	}
 	
 
@@ -50,13 +50,13 @@ class DiamondBL {
 		extract($bloglist_options);
 		$wgt_title = $diamond_bloglist_title;
 		$wgt_count = $diamond_bloglist_count;		
-		$wgt_miss = split(';', $diamond_bloglist_miss);		
+		$wgt_miss = explode(';', $diamond_bloglist_miss);		
 		$wgt_format = $diamond_bloglist_format;		
 		$wgt_avsize = $diamond_bloglist_avsize;		
 		$wgt_mtext = $diamond_bloglist_mtext;		
 		$wgt_defav = $diamond_bloglist_defav;		
 		$wgt_dt = $diamond_bloglist_dt;	
-		$wgt_white = split(';', $diamond_bloglist_white);
+		$wgt_white = explode(';', $diamond_bloglist_white);
 		$min_post_count = $diamond_bloglist_min_post_count; 
 		$comment_age = $wgt_diamond_bloglist_comment_age;
 	
@@ -326,7 +326,7 @@ class DiamondBL {
 		}
 		
 		$wgt_miss=$options['diamond_bloglist_miss'];
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="wgt_miss">' . __('Exclude blogs: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';
@@ -355,7 +355,7 @@ class DiamondBL {
 		}
 		
 		$wgt_miss=$options['diamond_bloglist_white'];
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="wgt_white">' . __('Whitelist: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';

--- a/diamond-broadcast-posts.php
+++ b/diamond-broadcast-posts.php
@@ -93,7 +93,7 @@
 			$blog_list = get_blog_list( ); 			
 			$shared = get_post_custom_values('diamond_broadcast_blogs', ($_GET['post']) ? $_GET['post'] : 0);
 			
-			$sharr = split(";", $shared[0]);
+			$sharr = explode(";", $shared[0]);
 			
 			foreach ($blog_list AS $blog) {
 				if ($blog['blog_id'] != $wpdb->blogid)

--- a/diamond-post-feed.php
+++ b/diamond-post-feed.php
@@ -27,9 +27,9 @@ class DiamondPF {
 	function diamond_post_create_feed() {
 		
 		$wgt_count=get_option('diamond_post_feed_count');		
-		$wgt_miss= split(';', get_option('diamond_post_feed_miss'));		
+		$wgt_miss= explode(';', get_option('diamond_post_feed_miss'));		
 		$wgt_format = get_option('diamond_post_feed_format');				
-		$wgt_white= split(';', get_option('diamond_post_feed_white'));		
+		$wgt_white= explode(';', get_option('diamond_post_feed_white'));		
 	
 		$this->render_output($wgt_miss, $wgt_count, $wgt_format, $wgt_white) ;		
 	}
@@ -154,7 +154,7 @@ class DiamondPF {
 		}
 		
 		$wgt_miss=get_option('diamond_post_feed_miss');
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="diamond_post_feed_miss">' . __('Exclude blogs: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';
@@ -182,7 +182,7 @@ class DiamondPF {
 		}
 		
 		$wgt_miss=get_option('diamond_post_feed_white');
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="diamond_post_feed_white">' . __('Whitelist: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';

--- a/diamond-recent-comments.php
+++ b/diamond-recent-comments.php
@@ -37,7 +37,7 @@ class DiamondRC {
 		), $atts ) );
 			
 
-		return $this->render_output(split(',',$exclude), $count, $format, $avatar_size, $default_avatar, $date_format, $before_item, $after_item, $before_content, $after_content, split(',', $whitelist), $comment_type);
+		return $this->render_output(explode(',',$exclude), $count, $format, $avatar_size, $default_avatar, $date_format, $before_item, $after_item, $before_content, $after_content, explode(',', $whitelist), $comment_type);
 	}
 	
 	function widget_endView($args)
@@ -45,13 +45,13 @@ class DiamondRC {
 		
 		$wgt_title=get_option('c_wgt_title');
 		$wgt_count=get_option('c_wgt_count');		
-		$wgt_miss= split(';', get_option('c_wgt_miss'));		
+		$wgt_miss= explode(';', get_option('c_wgt_miss'));		
 		$wgt_format= get_option('c_wgt_format');		
 		$wgt_avsize = get_option('wgtc_avsize');		
 		$wgt_mtext = get_option('wgtc_mtext');		
 		$wgt_defav = get_option('wgtc_defav');		
 		$wgt_dt = get_option('wgtc_dt');		
-		$wgt_white= split(';', get_option('c_wgt_white'));		
+		$wgt_white= explode(';', get_option('c_wgt_white'));		
 		
 		$output = '';
 		
@@ -217,7 +217,7 @@ class DiamondRC {
 		}
 		
 		$wgt_miss=get_option('c_wgt_miss');
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="wgt_miss">' . __('Exclude blogs: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';
@@ -245,7 +245,7 @@ class DiamondRC {
 		}
 		
 		$wgt_white=get_option('c_wgt_white');
-		$miss = split(';',$wgt_white);
+		$miss = explode(';',$wgt_white);
 		echo '<br /><label for="c_wgt_white">' . __('Whitelist: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';

--- a/diamond-recent-posts.php
+++ b/diamond-recent-posts.php
@@ -36,7 +36,7 @@ class DiamondRP {
 		'post_limit' => 0
 		), $atts ) );
 			
-		return $this->render_output(split(',',$exclude), $count, html_entity_decode($format), $avatar_size, $default_avatar, $date_format, html_entity_decode($before_item), html_entity_decode($after_item), html_entity_decode($before_content), html_entity_decode($after_content), $more_text, split(',', $whitelist), $post_limit);
+		return $this->render_output(explode(',',$exclude), $count, html_entity_decode($format), $avatar_size, $default_avatar, $date_format, html_entity_decode($before_item), html_entity_decode($after_item), html_entity_decode($before_content), html_entity_decode($after_content), $more_text, explode(',', $whitelist), $post_limit);
 	}
 	
 
@@ -44,13 +44,13 @@ class DiamondRP {
 	{		
 		$wgt_title=get_option('wgt_title');
 		$wgt_count=get_option('wgt_count');		
-		$wgt_miss= split(';', get_option('wgt_miss'));		
+		$wgt_miss= explode(';', get_option('wgt_miss'));		
 		$wgt_format = get_option('wgt_format');		
 		$wgt_avsize = get_option('wgt_avsize');		
 		$wgt_mtext = get_option('wgt_mtext');		
 		$wgt_defav = get_option('wgt_defav');		
 		$wgt_dt = get_option('wgt_dt');				
-		$wgt_white = split(';', get_option('wgt_white'));
+		$wgt_white = explode(';', get_option('wgt_white'));
 		$wgt_post_limit = get_option('wgt_post_limit');				
 		
 	
@@ -233,7 +233,7 @@ class DiamondRP {
 		}
 		
 		$wgt_miss=get_option('wgt_miss');
-		$miss = split(';',$wgt_miss);
+		$miss = explode(';',$wgt_miss);
 		echo '<br /><label for="wgt_miss">' . __('Exclude blogs: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';
@@ -260,7 +260,7 @@ class DiamondRP {
 		}
 		
 		$wgt_white=get_option('wgt_white');
-		$miss = split(';',$wgt_white);
+		$miss = explode(';',$wgt_white);
 		echo '<br /><label for="wgt_white">' . __('White List: (The first 50 blogs)','diamond');
 		$blog_list = get_blog_list( 0, 50 ); 
 		echo '<br />';


### PR DESCRIPTION
I just updated a site using diamond-multisite-widgets to PHP7 and the use of "split" made it crash and burn.  I am NOT a PHP programmer but replacing split with explode appeared to fix the problem and this is working using latest Wordpress on PHP 7.02.
